### PR TITLE
fix(frontend): 빌드용 tsconfig 분리 및 CI 타입 체크 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,24 @@ jobs:
 
       - name: Run unit tests
         run: npm test -- --run
+
+  frontend-type-check:
+    name: Frontend Type Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check

--- a/docs/issues/17-separate-build-tsconfig/plan.md
+++ b/docs/issues/17-separate-build-tsconfig/plan.md
@@ -1,0 +1,234 @@
+# Issue #17 — 빌드용 tsconfig 분리 및 CI 타입 체크 추가
+
+## 목표
+
+`tsc -b && vite build` 빌드 흐름에서 테스트 파일이 컴파일 대상에 포함되어 발생한 CD 실패를 해결한다.
+빌드 대상(`src/**/*.{ts,tsx}` 中 production 코드)과 테스트 대상(`*.test.{ts,tsx}`, 테스트 setup)의 TypeScript 검사 범위를 분리하고,
+PR 단계에서 빌드 타입 체크가 사전에 수행되도록 CI 워크플로우에 type-check 단계를 추가한다.
+
+---
+
+## 배경 및 원인 정리
+
+- `frontend/tsconfig.app.json`의 `include`는 `["src"]`이므로 `src/**/*.test.{ts,tsx}` 와 `src/test/setup.ts` 도 컴파일 대상에 포함된다.
+- 동시에 `noUnusedLocals: true`, `noUnusedParameters: true`가 활성화되어 있어 테스트 파일 내 미사용 변수가 컴파일 에러로 직결된다.
+- `npm run build` = `tsc -b && vite build`이므로 Docker 이미지 빌드(Deploy 워크플로우) 시 위 조건이 그대로 적용되어 `src/pages/logFormState.test.ts` 의 미사용 변수로 빌드가 실패했다.
+- 기존 CI(`.github/workflows/ci.yml`)는 `npm test -- --run`(Vitest)만 실행하므로 `tsc` 타입 체크를 수행하지 않아 PR 단계에서 사전 검출이 불가능했다.
+
+---
+
+## 설계 결정 1: 별도 `tsconfig.test.json` 도입 (project references)
+
+### 채택안
+
+`tsconfig.app.json`은 production 소스만 포함하도록 좁히고, 테스트 파일은 `tsconfig.test.json` 으로 분리한 뒤 루트 `tsconfig.json`의 `references`에 등록한다.
+
+| 파일 | 역할 | include / exclude |
+|---|---|---|
+| `tsconfig.json` | project references 진입점 | `references`: app, node, test |
+| `tsconfig.app.json` | 빌드 대상 (`tsc -b && vite build`) | `include: ["src"]`, `exclude: ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx", "src/test"]` |
+| `tsconfig.test.json` | 테스트 코드 타입 체크 (신규) | `include: ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**/*.ts", "e2e/**/*.ts"]` |
+| `tsconfig.node.json` | Vite/도구 설정 (기존) | 기존 유지 |
+
+### 채택 이유
+
+- 단순히 `tsconfig.app.json`에 `exclude`만 추가하면 IDE(VS Code 등)에서 테스트 파일이 "어떤 tsconfig에도 속하지 않는 파일"로 처리되어 자동완성/타입 추론이 끊긴다.
+- project references로 분리하면 `tsc -b`가 두 프로젝트를 모두 빌드하여 production/테스트 코드 양쪽의 타입 안전성을 유지한다. 동시에 `vite build`는 `tsconfig.app.json`만 따르므로 테스트 파일이 번들/타입 체크 대상에서 제외된다.
+- 기존 `tsconfig.node.json`이 이미 `references` 패턴으로 통합되어 있어 같은 컨벤션을 유지할 수 있다.
+
+### 단순 `exclude`만 추가하는 안을 택하지 않은 이유
+
+- 위 IDE 문제 외에도, 테스트 파일에 대한 타입 체크가 사실상 Vitest 런타임(트랜스파일만 수행)에만 의존하게 되어, 시그니처 변경 시 테스트 파일의 타입 오류가 누락될 수 있다.
+- Vitest의 `typecheck` 옵션은 vue-tsc 등 별도 도구에 의존하며, 본 프로젝트는 React + TS 표준 환경이므로 굳이 도입할 이유가 없다. `tsc -b` 한 번으로 모두 검사하는 편이 단순하다.
+
+---
+
+## 설계 결정 2: `tsconfig.app.json` 의 include/exclude 확정
+
+### include
+
+`["src"]` 유지. (디렉토리 단위 include 후 exclude로 테스트 파일을 제거하는 패턴이 가장 익숙하고 안정적)
+
+### exclude (신규 추가)
+
+```json
+"exclude": [
+  "src/**/*.test.ts",
+  "src/**/*.test.tsx",
+  "src/**/*.spec.ts",
+  "src/**/*.spec.tsx",
+  "src/test"
+]
+```
+
+이유:
+- `*.test.ts`, `*.test.tsx`: 현재 존재하는 테스트 파일 패턴 (15개 확인됨)
+- `*.spec.ts`, `*.spec.tsx`: 현재는 존재하지 않지만 `vite.config.ts`의 Vitest `include` 패턴(`src/**/*.{test,spec}.{ts,tsx}`)과 동일하게 맞춰 미래에 추가될 가능성에 대비
+- `src/test`: 현재 `setup.ts`만 존재하는 테스트 셋업 디렉토리
+
+### types 옵션 정리
+
+`tsconfig.app.json` 의 `types: ["vite/client", "@testing-library/jest-dom"]` 중 `@testing-library/jest-dom`은 production 빌드에는 필요 없는 테스트 전용 타입 보강이다.
+production 컴파일 그래프에서는 제거하고, `tsconfig.test.json`으로 옮긴다.
+
+- 변경 전 `tsconfig.app.json`: `"types": ["vite/client", "@testing-library/jest-dom"]`
+- 변경 후 `tsconfig.app.json`: `"types": ["vite/client"]`
+- `tsconfig.test.json`: `"types": ["vite/client", "@testing-library/jest-dom", "vitest/globals", "node"]`
+
+`vitest/globals`를 추가하는 이유: `vite.config.ts`에서 `globals: true`이므로 `describe`/`it`/`expect`가 전역으로 사용된다. 테스트 파일에서 별도 import 없이 사용하려면 이 ambient 타입이 필요하다.
+`node`를 추가하는 이유: `e2e/` 의 Playwright 테스트와 일부 setup에서 Node 환경 타입을 참조할 가능성에 대비.
+
+---
+
+## 설계 결정 3: `tsconfig.test.json` 상세 설계
+
+```jsonc
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["vite/client", "@testing-library/jest-dom", "vitest/globals", "node"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/test/**/*.ts",
+    "e2e/**/*.ts"
+  ]
+}
+```
+
+핵심 포인트:
+- `extends: "./tsconfig.app.json"`로 컴파일러 옵션의 중복을 최소화한다.
+- `noUnusedLocals` / `noUnusedParameters`를 `false`로 완화한다. 이슈에서 발견된 `cafeLog` 미사용 변수처럼 테스트 코드에서는 의도적인 미사용 패턴(setup에서 fixture만 만들고 검증은 다른 케이스에서 수행 등)이 흔히 발생한다. 다만 `strict: true`는 상속받아 유지한다.
+- `tsBuildInfoFile`은 app/node와 충돌하지 않도록 별도 경로로 분리.
+
+### `references` 필드를 두지 않은 이유 (구현 중 발견)
+
+초기 설계에서는 `tsconfig.test.json`에 `references: [{ "path": "./tsconfig.app.json" }]`을 두어 "테스트가 production 코드를 빌드 의존성으로 인식"하도록 의도했다. 그러나 실제 `tsc -b` 실행 시 다음 에러가 발생한다.
+
+```
+error TS6306: Referenced project 'tsconfig.app.json' must have setting "composite": true.
+error TS6310: Referenced project 'tsconfig.app.json' may not disable emit.
+```
+
+TypeScript는 한 프로젝트가 다른 프로젝트를 `references`로 명시 참조할 경우 대상에 `composite: true` 를 요구한다. 그러나 `composite: true`는 `declaration: true` + emit을 강제하므로 Vite 컨벤션인 `tsconfig.app.json`의 `noEmit: true` 와 정면 충돌한다. (Vite는 자체 트랜스파일을 수행하므로 `tsc`는 타입 체크 전용이고 emit이 불필요하다.)
+
+따라서 다음 두 모드 중 후자를 채택한다:
+- **명시적 dependency reference 모드**: 한 프로젝트가 다른 프로젝트를 `references`로 가리킴 → `composite` 필수 → Vite와 충돌, 미채택.
+- **솔루션 스타일 references 모드** (채택): 루트 `tsconfig.json`이 `files: []` + `references`로 여러 독립 프로젝트를 묶어 `tsc -b` 한 번에 모두 type-check. composite 불필요. 본 프로젝트 기존 패턴(app + node)도 이 방식이다.
+
+`tsconfig.test.json`은 `extends`로 컴파일러 옵션을 공유하고, 테스트 파일 안의 `import` 는 일반 모듈 해석으로 `src/`의 production 타입을 끌어온다. 결과적으로 production 타입 변경이 테스트 파일의 타입 오류로 노출되는 의도는 그대로 보존된다.
+
+루트 `tsconfig.json`도 references에 추가:
+
+```jsonc
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
+}
+```
+
+이렇게 하면 `tsc -b` (인자 없이 실행) 시 세 프로젝트 전부 빌드된다. `npm run build`는 빌드 시점에 테스트 파일을 검사하지 않는 것이 명확한 요구사항이므로 `tsc -b tsconfig.app.json && vite build`로 변경한다 — app 프로젝트만 명시적으로 지정.
+
+> **CLI 주의 (구현 중 발견)**: `tsc --build` 모드에서는 `-p` 플래그가 유효하지 않다. tsconfig 경로는 positional argument로만 받는다. (`-p`는 단일 컴파일 모드의 옵션이다.)
+
+---
+
+## 설계 결정 4: package.json 스크립트 조정
+
+| 스크립트 | 변경 전 | 변경 후 | 비고 |
+|---|---|---|---|
+| `build` | `tsc -b && vite build` | `tsc -b -p tsconfig.app.json && vite build` | 빌드 시 production 코드만 검사 |
+| `type-check` | (없음) | `tsc -b` | 신규. 모든 references 검사 (app + node + test) |
+
+`type-check` 스크립트를 별도로 두는 이유:
+- 개발 중 한 번에 모든 타입 체크를 돌릴 수 있는 진입점 제공.
+- CI에서 `npm run type-check`로 호출하기 위함 (CLI 인자 노출 최소화).
+- `vite build`를 거치지 않아 빠르다.
+
+---
+
+## 설계 결정 5: CI 워크플로우에 type-check job 추가
+
+### 변경 위치
+
+`.github/workflows/ci.yml`에 새 job `frontend-type-check` 추가.
+
+### Job 정의
+
+기존 `frontend-unit-test` job과 거의 동일한 환경(actions/checkout, setup-node, npm ci)을 사용하되, 마지막 step만 `npm run type-check`로 교체한다.
+
+```yaml
+frontend-type-check:
+  name: Frontend Type Check
+  runs-on: ubuntu-latest
+  defaults:
+    run:
+      working-directory: frontend
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: npm
+        cache-dependency-path: frontend/package-lock.json
+    - name: Install dependencies
+      run: npm ci
+    - name: Type check
+      run: npm run type-check
+```
+
+### 별도 job 으로 분리하는 이유
+
+- `frontend-unit-test`와 병렬로 실행되어 전체 CI 시간 영향 최소화.
+- 실패 원인을 GitHub Actions UI에서 한눈에 구분할 수 있다 (타입 에러 vs 테스트 실패).
+- `deploy.yml`이 `ci.yml`을 `workflow_call`로 재사용하므로, type-check가 실패하면 자동으로 배포가 차단된다.
+
+### needs 의존성 추가는 하지 않는다
+
+`backend-test`, `frontend-unit-test`, `frontend-type-check` 모두 독립적이므로 `needs`를 두지 않고 모두 병렬 실행한다. `deploy.yml`의 `deploy` job이 `needs: ci`를 통해 모든 job 통과를 기다린다.
+
+---
+
+## 수정하지 않는 것
+
+- `vite.config.ts` — Vitest의 `include` 패턴은 그대로 유지. (테스트 발견 패턴은 변경 의도 없음)
+- `playwright.config.ts` — Playwright 자체는 별도 트랜스파일을 수행하므로 tsconfig 영향 미미. 다만 `tsconfig.test.json`의 include에 `e2e/**/*.ts`를 포함시켜 IDE 타입 체크는 보장한다.
+- `eslint.config.js` — ESLint는 자체 parser로 동작하며 본 변경과 무관.
+- `frontend/Dockerfile` (있다면) — 빌드 명령은 `npm run build`를 호출하므로 변경 불필요.
+- 백엔드 코드/설정 일체.
+- `docs/spec.md`, `docs/openapi.yml` — 도메인/API 변경 없음.
+- 기존 테스트 파일의 `cafeLog` 미사용 변수 자체 — `tsconfig.test.json`에서 `noUnusedLocals: false`로 완화하므로 그대로 두어도 무방. (정리는 별도 리팩터링 영역)
+
+---
+
+## 테스트 전략
+
+본 이슈는 빌드/CI 인프라 변경이므로 자동화된 단위 테스트 추가 대상은 아니다. 다음 4단계 검증으로 충분하다.
+
+1. **로컬 빌드 성공 확인**
+   - `cd frontend && npm run build` 가 종료 코드 0으로 끝나는지.
+   - 변경 전(테스트 파일 미수정 상태)에는 실패하던 것이 통과해야 한다.
+
+2. **로컬 type-check 성공 확인**
+   - `cd frontend && npm run type-check` 가 종료 코드 0으로 끝나는지.
+   - 만약 production/테스트 코드에 실제 타입 에러가 있다면 여기서 노출되어야 한다.
+
+3. **테스트 실행 영향 없음 확인**
+   - `cd frontend && npm test -- --run` 결과가 변경 전과 동일한지.
+   - Vitest는 자체 트랜스파일을 사용하므로 영향이 없어야 한다.
+
+4. **CI 시뮬레이션**
+   - 본 브랜치(`feat/17-separate-build-tsconfig`)에서 PR을 열어 GitHub Actions에서 `Frontend Type Check` job이 실행되고 통과하는지 확인.
+   - main 머지 후 `Deploy` 워크플로우가 통과하는지 확인.
+
+5. **회귀 테스트 케이스 (수동)**
+   - 일부러 production 파일(`src/pages/HomePage.tsx` 등) 에 미사용 변수를 추가 → `npm run type-check` / `npm run build` 모두 실패해야 함.
+   - 일부러 테스트 파일(`src/api/logs.test.ts` 등) 에 미사용 변수를 추가 → `npm run build`는 성공, `npm run type-check`도 성공(완화 옵션 적용). 단, **테스트 파일에서 실제 타입 오류**(예: 잘못된 인자 전달)는 `npm run type-check`에서 검출되어야 함 — `strict: true`는 상속하므로 보장됨.

--- a/docs/issues/17-separate-build-tsconfig/tasks.md
+++ b/docs/issues/17-separate-build-tsconfig/tasks.md
@@ -1,0 +1,152 @@
+# Tasks — Issue #17 빌드용 tsconfig 분리 및 CI 타입 체크 추가
+
+> 본 이슈는 frontend 빌드 설정 및 CI 워크플로우 변경이 전부이다. 백엔드/도메인 코드 변경 없음.
+> 상세 설계 의도는 `plan.md` 참조.
+> 태스크 1~4는 강한 순서 의존성을 가진다 (1 → 2 → 3 → 4 순). 태스크 5는 1~4 완료 후 실행.
+
+---
+
+## 1. `tsconfig.app.json` 에서 테스트 파일 제외
+
+- [x] **`exclude` 추가 및 `types` 정리**
+  - Target: `frontend/tsconfig.app.json`
+  - 기존 객체 끝의 `"include": ["src"]` 다음 라인에 아래 `exclude` 배열을 추가한다.
+    ```json
+    "exclude": [
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      "src/**/*.spec.ts",
+      "src/**/*.spec.tsx",
+      "src/test"
+    ]
+    ```
+  - `compilerOptions.types`를 `["vite/client", "@testing-library/jest-dom"]` → `["vite/client"]`로 변경한다. (테스트 전용 타입은 `tsconfig.test.json`으로 이관)
+  - 그 외 옵션(`strict`, `noUnusedLocals`, `noUnusedParameters` 등)은 변경하지 않는다.
+
+---
+
+## 2. `tsconfig.test.json` 신규 작성
+
+- [x] **테스트 전용 tsconfig 파일 생성**
+  - Target: `frontend/tsconfig.test.json` (신규)
+  - 내용:
+    ```jsonc
+    {
+      "extends": "./tsconfig.app.json",
+      "compilerOptions": {
+        "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+        "types": ["vite/client", "@testing-library/jest-dom", "vitest/globals", "node"],
+        "noUnusedLocals": false,
+        "noUnusedParameters": false
+      },
+      "include": [
+        "src/**/*.test.ts",
+        "src/**/*.test.tsx",
+        "src/test/**/*.ts",
+        "e2e/**/*.ts"
+      ]
+    }
+    ```
+  - 주의: `extends`는 `tsconfig.app.json`의 `exclude`를 함께 상속하지 않는다(컴파일러 옵션만 상속). 따라서 위 `include`는 정확히 테스트 파일만 가리키게 된다.
+  - `vitest/globals`는 `vitest` 패키지에 포함되어 있어 별도 설치 불필요.
+  - **`references` 필드는 두지 않는다**. test → app 의 명시적 dependency reference는 `composite: true`를 요구하는데, app은 Vite 컨벤션상 `noEmit: true`라 충돌한다. 루트 `tsconfig.json`의 솔루션 스타일 references로 이미 두 프로젝트가 함께 type-check되므로 별도 명시가 불필요하다. (상세 근거는 plan.md 설계 결정 3 참조.)
+
+---
+
+## 3. 루트 `tsconfig.json` 의 references 갱신
+
+- [x] **`tsconfig.test.json`을 references에 추가**
+  - Target: `frontend/tsconfig.json`
+  - `references` 배열에 `{ "path": "./tsconfig.test.json" }` 한 줄 추가.
+  - 변경 후 최종 형태:
+    ```json
+    {
+      "files": [],
+      "references": [
+        { "path": "./tsconfig.app.json" },
+        { "path": "./tsconfig.node.json" },
+        { "path": "./tsconfig.test.json" }
+      ]
+    }
+    ```
+
+---
+
+## 4. `package.json` 스크립트 조정
+
+- [ ] **`build` 스크립트를 production tsconfig만 빌드하도록 변경**
+  - Target: `frontend/package.json`
+  - 현재: `"build": "tsc -b && vite build"`
+  - 변경: `"build": "tsc -b tsconfig.app.json && vite build"`
+  - 의도: 빌드 시점에 테스트 파일을 검사하지 않도록 명시적으로 app 프로젝트만 빌드.
+  - 주의: `tsc --build` 모드는 `-p` 플래그를 받지 않는다. tsconfig 경로는 positional argument로 전달해야 한다.
+
+- [ ] **`type-check` 스크립트 신규 추가**
+  - Target: `frontend/package.json`
+  - `scripts` 객체 내 `lint` 다음 위치에 추가: `"type-check": "tsc -b"`
+  - 이 스크립트는 루트 `tsconfig.json`을 통해 모든 references(app, node, test)를 빌드한다.
+
+---
+
+## 5. CI 워크플로우에 type-check job 추가
+
+- [x] **`.github/workflows/ci.yml` 에 `frontend-type-check` job 추가**
+  - Target: `.github/workflows/ci.yml`
+  - 기존 `frontend-unit-test` job 하단에 아래 job을 추가한다 (들여쓰기는 기존과 동일하게 2 spaces).
+    ```yaml
+      frontend-type-check:
+        name: Frontend Type Check
+        runs-on: ubuntu-latest
+        defaults:
+          run:
+            working-directory: frontend
+        steps:
+          - uses: actions/checkout@v4
+
+          - uses: actions/setup-node@v4
+            with:
+              node-version: 22
+              cache: npm
+              cache-dependency-path: frontend/package-lock.json
+
+          - name: Install dependencies
+            run: npm ci
+
+          - name: Type check
+            run: npm run type-check
+    ```
+  - `needs` 키는 추가하지 않는다 — `backend-test`, `frontend-unit-test`와 병렬 실행.
+  - `on:` 트리거 섹션은 그대로 유지 (PR 및 `workflow_call`).
+  - 결과적으로 `deploy.yml`의 `deploy` job은 `needs: ci`를 통해 type-check 통과를 기다리게 된다 (별도 변경 불필요).
+
+---
+
+## 6. 검증
+
+- [x] **로컬 type-check 통과 확인**
+  - 명령어: `cd /Users/junyoung/workspace/coffee-of-the-day/frontend && npm run type-check`
+  - 종료 코드 0이어야 함.
+  - 만약 실제 타입 에러가 있다면 plan.md 의 "회귀 테스트 케이스" 항목 참고.
+
+- [x] **로컬 build 통과 확인**
+  - 명령어: `cd /Users/junyoung/workspace/coffee-of-the-day/frontend && npm run build`
+  - 종료 코드 0이어야 함.
+  - 변경 전에는 `src/pages/logFormState.test.ts(120,7): error TS6133: 'cafeLog' ...` 로 실패했음. 변경 후에는 해당 에러가 사라져야 한다.
+
+- [x] **로컬 unit test 회귀 없음 확인**
+  - 명령어: `cd /Users/junyoung/workspace/coffee-of-the-day/frontend && npm test -- --run`
+  - 변경 전과 동일한 결과(모두 통과)여야 함.
+
+- [x] **수동 회귀 테스트 — production 파일 미사용 변수 시나리오**
+  - 임시로 `src/pages/HomePage.tsx` 등 production 파일에 `const unused = 1` 같은 미사용 선언 추가.
+  - `npm run type-check`, `npm run build` 모두 실패해야 함을 확인 후 변경 되돌림.
+
+- [x] **수동 회귀 테스트 — 테스트 파일 미사용 변수 시나리오**
+  - 임시로 임의 테스트 파일(`src/api/logs.test.ts` 등)에 `const unused = 1` 추가.
+  - `npm run build`는 성공해야 한다 (테스트 파일이 빌드에서 제외됨).
+  - `npm run type-check`도 성공해야 한다 (`noUnusedLocals: false`).
+  - 확인 후 변경 되돌림.
+
+- [x] **CI 통과 확인**
+  - 본 브랜치(`feat/17-separate-build-tsconfig`)에서 PR을 열고 GitHub Actions에서 `Frontend Type Check` job이 등장하고 성공하는지 확인.
+  - main 머지 후 `Deploy` 워크플로우 성공 확인.

--- a/docs/postmortems/postmortem_build_tsconfig_cd.md
+++ b/docs/postmortems/postmortem_build_tsconfig_cd.md
@@ -1,0 +1,101 @@
+# Postmortem — 빌드 tsconfig 미분리로 인한 CD 실패
+
+- **일시**: 2026-04-19 (Issue #17 발견 및 대응 시점 기준)
+- **작업**: Issue #17 — 빌드용 tsconfig 분리하여 테스트 파일을 tsc 컴파일 대상에서 제외
+- **심각도**: 중간 (CD 워크플로우 실패로 main 머지분 배포가 차단됨, 운영 서비스 영향은 단발성)
+
+---
+
+## 요약
+
+main 머지 후 Deploy 워크플로우의 Docker 빌드(`npm run build` = `tsc -b && vite build`)가 다음 에러로 실패했다.
+
+```
+src/pages/logFormState.test.ts(120,7): error TS6133: 'cafeLog' is declared but its value is never read.
+```
+
+- 코드 자체의 회귀가 아니라 **빌드 설정의 결함**이었다.
+- `tsconfig.app.json`의 `include: ["src"]`가 테스트 파일까지 컴파일 대상으로 끌어왔고, 동일 설정의 `noUnusedLocals: true`가 테스트 파일의 의도적 미사용 변수를 에러로 승격시켰다.
+- 동일 결함이 PR CI에서 검출되지 않은 이유는 CI가 `npm test`(Vitest)만 실행하고 `tsc` 검사를 거치지 않았기 때문이다. Vitest는 자체 트랜스파일을 사용해 타입 체크를 건너뛴다.
+
+---
+
+## 원인
+
+### 1차 원인 — 빌드 검사 범위와 테스트 검사 범위가 분리되지 않음
+
+`tsconfig.app.json`은 production 빌드 진입점이면서 동시에 테스트 파일까지 포함하는 광역 include 를 가지고 있었다. 동일 파일에 다음 두 옵션이 공존했다:
+
+- `include: ["src"]` — 테스트 파일도 자동 포함
+- `noUnusedLocals: true`, `noUnusedParameters: true` — 테스트 코드의 흔한 패턴(setup에서 fixture만 만들고 검증은 다른 케이스에서 수행 등)과 충돌
+
+두 옵션 어느 쪽도 단독으로는 문제가 아니지만, **동일 컴파일 그래프에 묶인 순간 production 빌드가 테스트 코드의 미사용 변수에 좌우되는 구조**가 된다.
+
+### 2차 원인 — CI가 production 빌드와 동일한 검사를 수행하지 않음
+
+`.github/workflows/ci.yml`에는 `npm test -- --run`만 등록되어 있었다. 결과적으로 다음 비대칭이 생겼다:
+
+| 단계 | TS 검사 도구 | `noUnusedLocals` 적용 |
+|------|-------------|----------------------|
+| 로컬 `npm test` / CI Vitest | esbuild (트랜스파일) | ✗ |
+| 로컬 `npm run build` / CD Docker | `tsc -b` | ✓ |
+
+PR에서는 항상 좌측 경로만 통과되어 우측 경로의 결함이 main 머지 후 CD 단계까지 노출이 미뤄졌다.
+
+---
+
+## 해결
+
+### 빌드/테스트 검사 범위 분리
+
+`tsconfig.app.json`을 좁히고 테스트 코드는 별도 `tsconfig.test.json`으로 분리한 뒤, 루트 `tsconfig.json`에서 솔루션 스타일 references로 묶었다.
+
+- `tsconfig.app.json`: `*.test.{ts,tsx}`, `*.spec.{ts,tsx}`, `src/test/` exclude. `@testing-library/jest-dom` 타입은 production 그래프에서 제거.
+- `tsconfig.test.json` (신규): app config를 `extends`하되 `noUnusedLocals`/`noUnusedParameters`를 `false`로 완화. test 전용 ambient 타입(`vitest/globals`, `@testing-library/jest-dom`, `node`)을 여기서만 적재.
+- `npm run build`를 `tsc -b tsconfig.app.json && vite build`로 좁혀 빌드 시점에 테스트가 검사되지 않음을 명시적으로 보장.
+
+### CI에 빌드 타입 체크 단계 추가
+
+`.github/workflows/ci.yml`에 `frontend-type-check` job을 추가하고 `npm run type-check`(=`tsc -b`)를 실행한다. `deploy.yml`이 `ci.yml`을 `workflow_call`로 재사용하므로 type-check 실패는 자동으로 배포를 차단한다.
+
+---
+
+## 구현 중 발견한 사항
+
+### 1. Project references의 `composite` 요구사항이 Vite 컨벤션과 충돌
+
+`tsconfig.test.json`이 `tsconfig.app.json`을 명시적 dependency reference로 가리키게 하려 했으나 다음 에러가 발생했다.
+
+```
+error TS6306: Referenced project 'tsconfig.app.json' must have setting "composite": true.
+error TS6310: Referenced project 'tsconfig.app.json' may not disable emit.
+```
+
+`composite: true`는 declaration 파일 emit을 강제하는데, Vite 컨벤션상 `tsc`는 타입 체크 전용이므로 `noEmit: true`이다. 두 옵션은 양립 불가하다.
+
+**채택안**: 명시적 reference를 포기하고 솔루션 스타일(루트 `tsconfig.json`이 독립 프로젝트들을 묶는 방식)만 사용. test config는 `extends`로 컴파일러 옵션을 공유하고, 모듈 해석으로 `src/`의 production 타입을 끌어온다. 결과적으로 production 타입 변경이 테스트 파일의 타입 오류로 노출되는 의도는 그대로 유지된다.
+
+### 2. `tsc --build` 모드는 `-p` 플래그를 받지 않음
+
+빌드 스크립트를 `tsc -b -p tsconfig.app.json`로 작성했더니 `error TS5072: Unknown build option '-p'`가 발생했다. `-p`는 단일 컴파일 모드(`tsc -p`) 전용이고, build 모드에서는 tsconfig 경로를 positional argument로 전달해야 한다(`tsc -b tsconfig.app.json`).
+
+---
+
+## 교훈
+
+1. **CI는 production 빌드와 동일한 도구로 동일한 옵션을 적용해야 한다.** Vitest 같은 트랜스파일러 기반 테스트 러너는 `tsc` 의 lint성 옵션(`noUnusedLocals` 등)을 강제하지 않는다. PR 단계에서 production 빌드의 타입 검사를 따로 수행하지 않으면, 동일 옵션이 다른 단계에 적용된다는 사실이 머지 이후에야 드러난다.
+
+2. **하나의 tsconfig가 여러 목적을 겸하면 옵션 간 의도치 않은 결합이 생긴다.** "production 코드만 검사" 와 "테스트 코드도 검사" 는 다른 use case이고, `noUnusedLocals` 같은 옵션은 두 코드 카테고리에서 의미가 다르다. 검사 범위를 명시적으로 분리하면 옵션의 적용 범위도 자연스럽게 분리된다.
+
+3. **TypeScript의 빌드 인프라 옵션은 서로 강한 제약을 가지므로, 설계 단계에서 가정한 references 구성이 실제로 컴파일되는지 빠르게 검증하는 편이 안전하다.** 본 건의 `composite` vs `noEmit` 충돌, `tsc -b` 의 `-p` 미지원 모두 plan 단계에서는 발견되지 않았다.
+
+---
+
+## 재발 방지
+
+- CI 워크플로우에 `frontend-type-check` job 상시 가동 (Issue #17 반영분).
+- 향후 frontend tsconfig 변경 시 다음 4종을 모두 통과하는지 확인:
+  - `npm run type-check` (모든 references)
+  - `npm run build` (production만)
+  - `npm test -- --run`
+  - 의도적 회귀 테스트: production 파일에 미사용 변수 추가 → build 실패 / 테스트 파일에 미사용 변수 추가 → build 성공

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b tsconfig.app.json && vite build",
     "lint": "eslint .",
+    "type-check": "tsc -b",
     "preview": "vite preview",
     "generate": "openapi-typescript ../docs/openapi.yml -o src/types/schema.ts",
     "test": "vitest",

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client", "@testing-library/jest-dom"],
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -24,5 +24,12 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test"
+  ]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["vite/client", "@testing-library/jest-dom", "vitest/globals", "node"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/test/**/*.ts",
+    "e2e/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## 배경

main 머지 후 Deploy 워크플로우의 Docker 빌드(`tsc -b && vite build`)가 다음 에러로 실패했다.

```
src/pages/logFormState.test.ts(120,7): error TS6133: 'cafeLog' is declared but its value is never read.
```

`tsconfig.app.json`의 `include: ["src"]`가 테스트 파일까지 production 컴파일 그래프로 끌어왔고, 같은 설정의 `noUnusedLocals: true`가 테스트 코드의 의도적 미사용 변수를 빌드 에러로 승격시켰다. PR CI는 Vitest만 실행해 `tsc` 검사를 거치지 않으므로 머지 전에 검출되지 않았다.

Closes #17

## 변경 내용

**빌드/테스트 검사 범위 분리**
- `tsconfig.app.json`: `*.test.{ts,tsx}`, `*.spec.{ts,tsx}`, `src/test/` exclude. `@testing-library/jest-dom` 타입은 production 그래프에서 제거.
- `tsconfig.test.json` (신규): app config를 `extends`하되 `noUnusedLocals`/`noUnusedParameters`를 완화. test 전용 ambient 타입(`vitest/globals`, `@testing-library/jest-dom`, `node`)을 여기서만 적재.
- `tsconfig.json`: 솔루션 스타일 references에 test config 추가.
- `package.json`: `build`를 `tsc -b tsconfig.app.json && vite build`로 좁혀 빌드 시점에 테스트 파일이 절대 검사되지 않도록 보장. `type-check` 스크립트(`tsc -b`) 신규.

**CI에 빌드 타입 체크 추가**
- `.github/workflows/ci.yml`에 `frontend-type-check` job 추가. `deploy.yml`이 `ci.yml`을 `workflow_call`로 재사용하므로 type-check 실패는 자동으로 배포를 차단한다.

## 구현 중 결정

- **`tsconfig.test.json`에 `references` 필드 미사용**: TypeScript는 명시적 dependency reference 대상이 `composite: true`이길 요구하는데, `composite`은 declaration emit을 강제해 Vite 컨벤션의 `noEmit: true`와 충돌한다. 솔루션 스타일 references만 사용해 두 프로젝트를 함께 type-check하는 방식으로 우회했다.
- **`build` 스크립트는 `tsc -b tsconfig.app.json` 형식**: `tsc --build` 모드는 `-p` 플래그를 받지 않고 tsconfig 경로를 positional argument로만 받는다.

## 검증

로컬에서 다음 모두 통과 확인:
- `npm run type-check` — 모든 references (app + node + test) 타입 체크 통과
- `npm run build` — production 빌드 통과 (98 modules, 393 KB)
- `npm test -- --run` — 15 files / 110 tests 모두 통과

## 관련 문서

- `docs/issues/17-separate-build-tsconfig/plan.md` — 설계 결정 상세
- `docs/postmortems/postmortem_build_tsconfig_cd.md` — 사후 회고