### PR TITLE
ci: upgrade GitHub Actions to Node 24 supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     name: Backend Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -27,9 +27,9 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -48,9 +48,9 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/docs/issues/19-actions-node24-upgrade/plan.md
+++ b/docs/issues/19-actions-node24-upgrade/plan.md
@@ -1,0 +1,138 @@
+# Issue #19 — GitHub Actions Node.js 20 런타임 deprecation 대응
+
+## 목표
+
+`.github/workflows/ci.yml`, `.github/workflows/deploy.yml`에서 사용 중인 GitHub-maintained 액션 3종(`actions/checkout`, `actions/setup-node`, `actions/setup-go`)을 Node 24 런타임을 사용하는 최신 메이저 버전으로 업그레이드한다.
+작업 종료 시점 기준으로 main 브랜치의 CI/Deploy 워크플로우 실행 로그에서 `Node.js 20 actions are deprecated.` 경고가 사라지고, 모든 기존 step(backend test, frontend unit test, frontend type check, fly deploy)이 회귀 없이 통과해야 한다.
+
+---
+
+## 배경 및 일정 압박
+
+GitHub은 2025-09-19 공지로 Actions runner의 Node 20 런타임 단계적 폐기를 선언했다. 본 이슈가 작성된 2026-04-19 시점에는 강제 전환까지 약 5개월 여유가 있었으나, 작업 시작 시점인 2026-05-10 기준으로는 다음과 같이 마감이 가까워졌다.
+
+- **2026-06-02 (3주 뒤)**: 기본 동작이 Node 24 강제 전환으로 바뀜. 이전 메이저(`@v4` 등)에 묶여 있는 액션은 의도와 다른 런타임에서 실행되며 경고가 에러로 격상될 가능성이 있음.
+- **2026-09-16 (~4개월 뒤)**: Node 20 런타임이 runner에서 완전히 제거됨. 이 시점 이후 미대응 액션은 실행 자체가 실패할 수 있음.
+
+따라서 본 이슈는 2026-06-02 이전에 main에 머지되어야 안전하다. 임시 회피책(`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`)은 본질적 해법이 아니며, 액션 메이저 버전 자체를 올리는 것이 정공법이다.
+
+---
+
+## 영향 범위 (현재 사용 위치)
+
+`grep`으로 사전 확인한 결과, GitHub-maintained 액션의 사용 위치는 다음과 같다.
+
+| 파일 | 라인 | 액션 | 현재 핀 | 입력 사용 |
+|---|---|---|---|---|
+| `.github/workflows/ci.yml` | 14 | `actions/checkout` | `@v4` | (없음) |
+| `.github/workflows/ci.yml` | 16 | `actions/setup-go` | `@v5` | `go-version-file: go.mod` |
+| `.github/workflows/ci.yml` | 30 | `actions/checkout` | `@v4` | (없음) |
+| `.github/workflows/ci.yml` | 32 | `actions/setup-node` | `@v4` | `node-version: 22`, `cache: npm`, `cache-dependency-path: frontend/package-lock.json` |
+| `.github/workflows/ci.yml` | 51 | `actions/checkout` | `@v4` | (없음) |
+| `.github/workflows/ci.yml` | 53 | `actions/setup-node` | `@v4` | `node-version: 22`, `cache: npm`, `cache-dependency-path: frontend/package-lock.json` |
+| `.github/workflows/deploy.yml` | 22 | `actions/checkout` | `@v4` | (없음) |
+
+`deploy.yml` 24행의 `superfly/flyctl-actions/setup-flyctl@master`는 GitHub-maintained가 아니므로 본 이슈 범위에서 제외한다(별도 backlog 후보).
+
+`ci.yml`은 `workflow_call` 트리거를 노출하고 `deploy.yml`이 `uses: ./.github/workflows/ci.yml`로 재사용한다(`deploy.yml:14-15`). 즉 PR에서 `ci.yml` 자체가 검증되면 deploy 흐름까지 자연스럽게 같은 액션 버전으로 검증되며, deploy job 자체가 사용하는 `actions/checkout`도 함께 업그레이드해야 deploy 실행 로그에서 경고가 완전히 사라진다.
+
+---
+
+## 설계 결정 1: 업그레이드 목표 버전
+
+각 액션의 GitHub Releases를 조사하여 Node 24 런타임을 채택한 최초 메이저와 최신 메이저를 확인했다.
+
+| 액션 | 현재 | 업그레이드 목표 | Node 24 도입 시점 | 비고 |
+|---|---|---|---|---|
+| `actions/checkout` | `@v4` | `@v5` | v5.0.0 (2024-08-11) — "Update actions checkout to use node 24" | v6도 존재(v6.0.x)하지만 v6는 자격증명 저장 방식 변경(`persist creds to a separate file`)으로 runner v2.329.0+ 요구. self-hosted runner 사용 시 호환성 점검이 필요. 본 프로젝트는 `ubuntu-latest`(GitHub-hosted)만 사용하므로 v6도 무방하지만, 변화 폭을 최소화하고 입력 schema가 동일한 v5를 채택한다. |
+| `actions/setup-node` | `@v4` | `@v5` | v5.0.0 (2025-09-04 무렵, "Upgrade action to use node24") | 현재 사용 중인 입력(`node-version`, `cache`, `cache-dependency-path`)은 v5/v6에서도 그대로 지원. v6에서 자동 캐싱이 npm 한정으로 축소되었으나, 본 프로젝트는 어차피 npm + 명시적 `cache: npm`이므로 v6도 안전. v5 채택. |
+| `actions/setup-go` | `@v5` | `@v6` | v6.0.0 ("Upgrade Nodejs runtime from node20 to node 24") | 본 프로젝트는 `go-version-file: go.mod` 사용 — v6에서도 지원 유지. 툴체인 처리 로직이 개선되었으나 `go-version-file`만 사용하는 본 프로젝트의 동작에는 영향 없음. |
+
+### v5 vs v6 (`actions/checkout`) 선택 근거
+
+- v6.0.0 changelog의 핵심 변경은 "credentials를 git config 대신 별도 파일로 분리 저장"이며 runner 최소 버전 v2.329.0을 요구한다. `ubuntu-latest`는 충분히 이 요건을 만족한다.
+- 그럼에도 v5를 채택하는 이유: (1) 본 이슈의 목적은 deprecation 경고 해소이므로 Node 24 도입 최초 메이저인 v5로 충분하다. (2) v5는 입력/동작이 v4와 사실상 동일해 회귀 위험이 가장 낮다. (3) 추가 안정화가 필요하면 후속 이슈에서 v6로 올리면 된다.
+
+### v5 vs v6 (`actions/setup-node`) 선택 근거
+
+- v6.0.0의 breaking change는 "자동 캐싱이 npm 한정으로 좁혀짐"이다. 본 프로젝트는 명시적으로 `cache: npm`을 지정하므로 영향이 없으며 v6도 안전하다.
+- 그러나 v5와 v6 모두 Node 24를 사용하므로 deprecation 해소 측면에서는 동일하며, 변경 폭을 최소화하기 위해 v5 채택. 추후 자동 캐싱 동작 변화가 필요해지면 v6로 올린다.
+
+### `actions/setup-go` v6 채택
+
+- 본 프로젝트의 입력은 `go-version-file: go.mod` 한 가지이며, v6에서도 그대로 지원된다.
+- v6는 Node 24 런타임 + 툴체인 처리 개선이 핵심이고, 입력 schema 호환성이 보장되므로 최신 메이저로 업그레이드해도 회귀 위험이 낮다.
+
+---
+
+## 설계 결정 2: 변경 형태 — 핀 문자열 단순 치환
+
+워크플로우 YAML의 `uses:` 라인의 메이저 버전 핀 문자열만 교체한다. 다음 규칙으로 일관되게 변경한다.
+
+- `actions/checkout@v4` → `actions/checkout@v5`
+- `actions/setup-node@v4` → `actions/setup-node@v5`
+- `actions/setup-go@v5` → `actions/setup-go@v6`
+
+### 패치 수준 핀(`@v5.0.1` 등) 대신 메이저 핀을 유지하는 이유
+
+- 기존 워크플로우가 메이저 핀(`@v4`, `@v5`) 컨벤션을 따르고 있어 일관성 유지가 자연스럽다.
+- GitHub Actions 메이저 태그는 같은 메이저 내 패치/마이너 업데이트를 자동 추적해 보안 패치 수신에 유리하다.
+- 본 프로젝트는 단일 사용자 POC이며 supply-chain 공격 모델에 대한 SHA 핀(`@<commit-sha>`)까지 도입할 필요가 낮다(향후 별도 backlog로 검토 가능).
+
+### 입력(`with:` 블록)은 변경하지 않는다
+
+위 표에서 확인한 대로 현재 사용 중인 모든 입력(`node-version`, `cache`, `cache-dependency-path`, `go-version-file`)이 목표 메이저에서 그대로 호환된다. 따라서 `with:` 블록은 손대지 않으며, 기존 들여쓰기/포맷도 그대로 유지한다.
+
+---
+
+## 설계 결정 3: 검증 전략 — PR CI 실행으로 단일 확인
+
+### 로컬 재현은 시도하지 않는다
+
+- `act` 등 도구로 GitHub Actions를 로컬 재현하는 방법이 있으나, runner 이미지 차이로 인해 deprecation 경고 발생/소거 여부를 정확히 검증하기 어렵다.
+- 본 변경은 액션 핀 6개를 치환하는 텍스트 수준의 변경이며, 실 환경에서 단 한 번 실행해 검증하는 비용이 가장 낮다.
+
+### 검증 절차
+
+1. **PR 생성**: `feat/19-actions-node24-upgrade` 브랜치에서 PR을 연다. PR 트리거(`pull_request: branches: [main]`)에 의해 `ci.yml`이 자동 실행된다.
+2. **CI job 통과 확인**: GitHub Actions UI에서 `backend-test`, `frontend-unit-test`, `frontend-type-check` 세 job이 모두 성공해야 한다.
+3. **deprecation 경고 소거 확인**: 각 job의 step별 raw 로그에서 `Node.js 20 actions are deprecated` 문자열이 더 이상 출력되지 않아야 한다. 특히 다음 step의 시작 부분 로그를 확인한다.
+   - `backend-test`: `Set up Go` (setup-go@v6)
+   - `frontend-unit-test`, `frontend-type-check`: `Set up Node` (setup-node@v5)
+   - 모든 job: `Run actions/checkout@v5`
+4. **main 머지 후 Deploy 검증**: PR 머지 후 자동 트리거되는 `Deploy` 워크플로우가 ci 단계 + deploy job(`actions/checkout@v5` 사용) 모두 통과하고, deprecation 경고가 deploy 로그에서도 사라졌는지 확인한다. fly.io 배포 자체가 정상 완료되어 사이트가 살아 있어야 한다.
+
+### 실패 시 롤백
+
+- PR 단계에서 어느 job이든 실패하면 즉시 변경을 되돌리고 실패 원인을 분석한다.
+- 가장 가능성 높은 실패 케이스는 `actions/setup-go@v6`의 툴체인 동작 변화로 추정된다. 이 경우 `setup-go@v6` → `setup-go@v5`로만 되돌리고(나머지 두 액션은 v5 유지), 별도 후속 이슈로 분리해 처리한다.
+- main에 머지된 후 deploy에서만 실패가 발견되는 시나리오는 ci.yml이 `workflow_call`로 deploy.yml에서 재사용되므로 가능성이 낮다. 그래도 발생 시 `Revert "feat: ..."` 커밋으로 즉시 롤백 후 재조사한다.
+
+---
+
+## 수정하지 않는 것
+
+- `superfly/flyctl-actions/setup-flyctl@master` (`.github/workflows/deploy.yml:24`) — GitHub-maintained가 아니며, 별도 deprecation 영향도 다르다. 필요 시 별도 backlog로 분리.
+- 워크플로우의 트리거 섹션(`on:`) — `pull_request`, `workflow_call`, `push` 트리거 정의는 본 이슈와 무관.
+- job 구성, step 순서, `needs`, `concurrency`, `defaults` 등 모든 워크플로우 토폴로지 — 핀 버전 외 어떤 것도 손대지 않는다.
+- 액션 입력(`with:` 블록) — 호환성이 확인되었으므로 그대로 유지.
+- 백엔드/프론트엔드 코드, `docs/spec.md`, `docs/openapi.yml`, `docs/arch/*` — 본 이슈는 인프라 메타데이터 변경이며 애플리케이션 동작/스펙에 영향 없음.
+- `docs/backlog.md` — 본 이슈는 backlog 항목으로 등재되어 있지 않으며, 신규 후속 작업도 본 이슈 범위 밖이다.
+
+---
+
+## 테스트 전략
+
+본 이슈는 GitHub Actions 워크플로우 메타데이터 변경이며, 자동화된 단위/통합 테스트 추가 대상은 아니다. 다음 두 단계로 충분하다.
+
+1. **YAML 정합성 빠른 점검 (선택, 로컬)**
+   - `actionlint`가 설치되어 있다면 `actionlint .github/workflows/ci.yml .github/workflows/deploy.yml` 실행. 미설치 시 생략 가능 (PR CI에서 어차피 잡힌다).
+
+2. **PR 단위 실 환경 검증 (필수)**
+   - 위 "설계 결정 3: 검증 전략"의 1~4 절차를 그대로 수행.
+   - 핵심 통과 조건:
+     - `ci.yml` 모든 job (`backend-test`, `frontend-unit-test`, `frontend-type-check`) 성공.
+     - 각 job 로그에 `Node.js 20 actions are deprecated` 메시지가 0회 출현.
+     - main 머지 후 `Deploy` 워크플로우 성공 + fly.io 사이트 정상 응답.
+
+회귀 위험이 낮은 변경이지만, deploy까지 통과 확인이 끝나야 본 이슈 종료로 간주한다.

--- a/docs/issues/19-actions-node24-upgrade/tasks.md
+++ b/docs/issues/19-actions-node24-upgrade/tasks.md
@@ -1,0 +1,83 @@
+# Tasks — Issue #19 GitHub Actions Node.js 20 런타임 deprecation 대응
+
+> 본 이슈는 `.github/workflows/*.yml`의 액션 메이저 핀 버전만 교체하는 인프라 변경이다.
+> 백엔드/프론트엔드 코드, 도메인 스펙, OpenAPI 스펙 모두 변경 없음.
+> 상세 설계 의도와 버전 선정 근거는 `plan.md` 참조.
+> 작업 브랜치는 이미 `feat/19-actions-node24-upgrade`로 생성되어 있다.
+> 태스크 1, 2는 독립적이며 순서 무관. 태스크 3은 1, 2 완료 후 PR 단계에서 수행.
+
+---
+
+## 1. `.github/workflows/ci.yml` 액션 핀 업그레이드
+
+- [ ] **`actions/checkout@v4` → `actions/checkout@v5` 일괄 치환**
+  - Target: `.github/workflows/ci.yml`
+  - 대상 라인: 14, 30, 51 (총 3곳).
+  - 각 라인의 `- uses: actions/checkout@v4`를 `- uses: actions/checkout@v5`로 변경.
+  - 들여쓰기, 라인 위치, 주변 빈 줄은 그대로 유지.
+  - `with:` 블록이 없는 형태이므로 추가 입력 변경 없음.
+
+- [ ] **`actions/setup-node@v4` → `actions/setup-node@v5` 일괄 치환**
+  - Target: `.github/workflows/ci.yml`
+  - 대상 라인: 32, 53 (총 2곳).
+  - 각 라인의 `- uses: actions/setup-node@v4`를 `- uses: actions/setup-node@v5`로 변경.
+  - 바로 아래 `with:` 블록(`node-version: 22`, `cache: npm`, `cache-dependency-path: frontend/package-lock.json`)은 그대로 유지. v5에서도 동일하게 지원된다.
+
+- [ ] **`actions/setup-go@v5` → `actions/setup-go@v6` 치환**
+  - Target: `.github/workflows/ci.yml`
+  - 대상 라인: 16 (1곳).
+  - `- uses: actions/setup-go@v5`를 `- uses: actions/setup-go@v6`로 변경.
+  - 바로 아래 `with:` 블록(`go-version-file: go.mod`)은 그대로 유지. v6에서도 동일하게 지원된다.
+
+---
+
+## 2. `.github/workflows/deploy.yml` 액션 핀 업그레이드
+
+- [ ] **`actions/checkout@v4` → `actions/checkout@v5` 치환**
+  - Target: `.github/workflows/deploy.yml`
+  - 대상 라인: 22 (1곳, deploy job 내부).
+  - `- uses: actions/checkout@v4`를 `- uses: actions/checkout@v5`로 변경.
+  - **변경하지 말 것**: 24행 `superfly/flyctl-actions/setup-flyctl@master`는 본 이슈 범위 외.
+  - **변경하지 말 것**: 14-15행 `uses: ./.github/workflows/ci.yml` (로컬 워크플로우 재사용 — 액션 핀 아님).
+  - `concurrency`, `needs: ci`, `env: FLY_API_TOKEN` 등 다른 모든 설정은 그대로 유지.
+
+---
+
+## 3. 검증 (PR 생성 및 실 환경 실행)
+
+- [ ] **로컬 YAML 정합성 빠른 점검 (선택)**
+  - 명령어 (actionlint 설치 시): `actionlint .github/workflows/ci.yml .github/workflows/deploy.yml`
+  - 미설치 시 생략. PR CI에서 어차피 잡힌다.
+
+- [ ] **변경 사항 커밋 및 PR 생성**
+  - 사용자 승인 후 `feat/19-actions-node24-upgrade` 브랜치에 변경을 커밋하고 push.
+  - PR 본문에 plan.md 핵심 요점(Node 20 deprecation 대응, 업그레이드 매트릭스, 검증 절차) 요약 포함.
+  - PR 트리거(`pull_request: branches: [main]`)에 의해 `ci.yml`이 자동 실행됨.
+
+- [ ] **PR CI job 전체 통과 확인**
+  - GitHub Actions UI에서 다음 3개 job이 모두 success여야 함.
+    - `Backend Test` (backend-test)
+    - `Frontend Unit Test` (frontend-unit-test)
+    - `Frontend Type Check` (frontend-type-check)
+  - 어느 하나라도 실패 시 plan.md "실패 시 롤백" 절차 참조.
+
+- [ ] **deprecation 경고 소거 확인**
+  - 각 job의 raw 로그를 열어 다음 step 시작 부분에서 `Node.js 20 actions are deprecated` 문자열이 더 이상 등장하지 않음을 확인.
+    - `backend-test` → `Set up Go` step (setup-go@v6)
+    - `frontend-unit-test` → `Set up Node` step (setup-node@v5)
+    - `frontend-type-check` → `Set up Node` step (setup-node@v5)
+    - 모든 job → `Run actions/checkout@v5` step
+  - 빠른 검색: 로그에서 "deprecated" 키워드로 grep해 0건이어야 함.
+
+- [ ] **main 머지 후 Deploy 워크플로우 검증**
+  - PR squash-merge 후 자동 트리거되는 `Deploy` 워크플로우 실행 결과 확인.
+  - 다음 모두 만족해야 함:
+    - 재사용된 ci 단계 통과 (3개 job 모두 success).
+    - deploy job의 `Run actions/checkout@v5` step에서 deprecation 경고 없음.
+    - `flyctl deploy --remote-only`가 정상 완료.
+    - fly.io 사이트가 평소대로 응답(루트 페이지 200 OK 등 간단 확인).
+  - 이상 시 즉시 revert 커밋으로 롤백 후 재조사.
+
+- [ ] **머지 후 정리**
+  - 작업 브랜치 `feat/19-actions-node24-upgrade` 원격/로컬 삭제.
+  - 이슈 #19 close (PR 머지 시 자동 close되도록 PR 본문에 `Closes #19` 포함).

--- a/docs/issues/9-draft-save/review/code_review.md
+++ b/docs/issues/9-draft-save/review/code_review.md
@@ -1,0 +1,240 @@
+# 코드 리뷰
+
+## 리뷰 범위
+
+- **브랜치**: `feat/9-draft-save`
+- **비교 기준**: `main...HEAD` (8커밋)
+- **변경 파일**:
+  - `backend/db/migrations/008_add_status_to_coffee_logs.{up,down}.sql`
+  - `backend/db/queries/coffee_logs.sql`, `suggestions.sql`
+  - `backend/internal/db/coffee_logs.sql.go`, `models.go`
+  - `backend/internal/domain/log.go`
+  - `backend/internal/handler/log_handler.go`, `log_handler_test.go`
+  - `backend/internal/repository/log_repository.go`, `log_repository_test.go`, `suggestion_repository.go`, `suggestion_repository_test.go`
+  - `backend/internal/service/log_service.go`, `log_service_test.go`
+  - `docs/backlog.md`, `docs/spec.md`, `docs/openapi.yml`
+  - `docs/issues/9-draft-save/plan.md`, `tasks.md`
+  - `frontend/src/api/logs.ts`
+  - `frontend/src/components/LogCard.tsx`, `LogCard.test.tsx`
+  - `frontend/src/pages/HomePage.tsx`, `LogDetailPage.tsx`, `LogFormPage.tsx`, `LogFormPage.test.tsx`
+  - `frontend/src/pages/logFormState.ts`, `logFormState.test.ts`
+  - `frontend/src/types/log.ts`, `schema.ts`
+
+## 요약
+
+`status` 컬럼 추가(draft/published)를 통한 드래프트 저장 기능 구현이다. 아키텍처 설계(NOT NULL + 빈 문자열 전략, service 레이어 status 전이 검증, suggestion 격리)는 plan.md와 충실히 일치하며, 테스트 커버리지도 service/handler/repository 전 레이어에 걸쳐 계획한 케이스 대부분을 달성했다. 다만 기존 `suggestion_repository_test.go`의 `status` 컬럼 누락으로 인한 테스트 격리 파괴 위험, `LogFormPage.test.tsx`의 임시 저장 버튼 관련 테스트 미작성, `LogDetailPage.tsx`의 로딩 중 UI 노출 문제, `LogCard.tsx`의 "View log" 문구 혼선 등 수정이 필요한 항목들이 존재한다.
+
+---
+
+## 발견 사항
+
+### [High] 기존 suggestion 테스트에서 `status` 컬럼 누락으로 인한 DB 제약 위반 위험
+
+- **파일**: `backend/internal/repository/suggestion_repository_test.go:37-55`, `57-80`, `82-105`, `107-135`, `137-161`, `163-187`, `193-217`, `219-240`, `242-263`
+- **카테고리**: Quality
+- **현재**: `008_add_status_to_coffee_logs.up.sql` 마이그레이션이 `status TEXT NOT NULL DEFAULT 'published' CHECK(status IN ('draft', 'published'))`를 추가했다. 그런데 기존 suggestion 테스트의 `INSERT INTO coffee_logs` 구문들은 `status` 컬럼을 명시하지 않는다. SQLite에서 `DEFAULT` 절이 있으므로 런타임에는 통과하지만, 마이그레이션 순서나 SQLite 버전에 따라 `DEFAULT` 처리 여부가 달라질 수 있다. 더 큰 문제는 새로 추가된 `TestGetTagSuggestions_DraftLog_Excluded`, `TestGetCompanionSuggestions_DraftLog_Excluded` 테스트는 `status`를 명시하는데, 바로 위 기존 테스트들은 명시하지 않아 코드 스타일이 일관되지 않으며 차후 테스트 픽스처가 잘못된 status로 삽입될 위험이 있다.
+- **제안**: 기존 `INSERT INTO coffee_logs` 구문에 `status` 컬럼과 값을 명시적으로 추가한다.
+
+  ```go
+  // 기존
+  `INSERT INTO coffee_logs (id, user_id, recorded_at, companions, log_type, created_at, updated_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  "log-1", testUserID, now, "[]", "cafe", now, now,
+
+  // 변경
+  `INSERT INTO coffee_logs (id, user_id, recorded_at, companions, log_type, status, created_at, updated_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  "log-1", testUserID, now, "[]", "cafe", "published", now, now,
+  ```
+- **근거**: AGENTS.md "항상 테스트를 작성할 것" 정책 및 테스트 격리 원칙. 기존 suggestion 테스트가 `status` 필터 동작을 가정하고 있으므로 픽스처가 정확한 status 값을 갖도록 보장해야 한다.
+
+---
+
+### [High] `LogFormPage.test.tsx`에 임시 저장 관련 테스트 미작성
+
+- **파일**: `frontend/src/pages/LogFormPage.test.tsx`
+- **카테고리**: Quality
+- **현재**: `LogFormPage.test.tsx`는 clone/recipe-picker 모드 테스트만 포함하고, plan.md와 tasks.md에서 명시한 임시 저장 버튼 관련 케이스(신규 cafe 폼에서 "임시 저장" 표시, 빈 폼에서 disabled, cafe_name 입력 후 enabled, 클릭 시 `createLog`에 `status: 'draft'` 전달 및 홈으로 navigate, published 수정 모드에서 버튼 미표시, draft 수정 모드에서 표시 및 클릭 시 `updateLog`에 `status: 'draft'` 전달)가 전혀 구현되어 있지 않다.
+- **제안**: 아래 케이스를 `LogFormPage.test.tsx`에 추가한다.
+
+  ```tsx
+  describe('임시 저장 버튼', () => {
+    it('신규 cafe 폼에서 "임시 저장" 버튼이 표시된다', () => {
+      renderNewMode()
+      expect(screen.getByRole('button', { name: '임시 저장' })).toBeInTheDocument()
+    })
+
+    it('cafe_name/coffee_name이 모두 비어있으면 "임시 저장" 버튼이 disabled다', () => {
+      renderNewMode()
+      expect(screen.getByRole('button', { name: '임시 저장' })).toBeDisabled()
+    })
+
+    it('cafe_name 입력 후 "임시 저장"이 활성화된다', async () => {
+      renderNewMode()
+      fireEvent.change(screen.getByLabelText(/Cafe name/), { target: { value: '블루보틀' } })
+      expect(screen.getByRole('button', { name: '임시 저장' })).toBeEnabled()
+    })
+
+    it('published 수정 모드에서는 "임시 저장" 버튼이 없다', () => {
+      // useLog mock을 published 로그로 오버라이드하는 테스트
+      // ...
+    })
+  })
+  ```
+- **근거**: AGENTS.md "기능 추가/수정 시 항상 테스트 작성" 정책. plan.md 테스트 전략 섹션에 명시된 케이스들이 미구현 상태다.
+
+---
+
+### [Medium] `LogDetailPage.tsx`에서 드래프트 redirect 중 UI가 brief하게 노출됨
+
+- **파일**: `frontend/src/pages/LogDetailPage.tsx:78-82`
+- **카테고리**: Quality
+- **현재**: `useEffect`로 `log?.status === 'draft'`를 감지해 redirect하지만, `log`가 로드되기 전까지 빈 상태가 렌더되고, 로드 완료 후 `useEffect`가 실행되므로 draft 로그 상세 내용이 한 프레임 이상 노출될 수 있다. 특히 `log`가 draft이면서 `isLoading`이 false인 시점에 `{log ? <div>...상세 내용...</div>}` 블록이 렌더된 뒤 redirect 처리가 일어난다.
+
+  ```tsx
+  // 현재: 렌더 이후 effect에서 redirect
+  useEffect(() => {
+    if (log?.status === 'draft' && id) {
+      navigate(`/logs/${id}/edit`, { replace: true })
+    }
+  }, [log?.status, id, navigate])
+
+  // ...
+
+  {log ? (
+    <div className="space-y-6">
+      {/* draft 상세 내용이 한 프레임 노출될 수 있다 */}
+    </div>
+  ) : null}
+  ```
+- **제안**: `log`가 있고 draft인 경우 상세 컨텐츠 렌더를 건너뛴다.
+
+  ```tsx
+  // 로딩 중이거나 드래프트 redirect 대기 중이면 컨텐츠를 렌더하지 않는다
+  {log && log.status !== 'draft' ? (
+    <div className="space-y-6">
+      {/* 상세 내용 */}
+    </div>
+  ) : null}
+  ```
+- **근거**: plan.md "드래프트는 상세 화면에서 보여줄 의미 있는 정보가 적으므로 곧바로 수정 폼으로 보낸다"는 설계 의도와 일치시키기 위함. draft 상세 내용이 순간적으로 노출되는 것은 의도하지 않은 UX다.
+
+---
+
+### [Medium] `normalizeListFilter`의 `limit` 중복 검사 (dead code)
+
+- **파일**: `backend/internal/service/log_service.go:401-414`
+- **카테고리**: Quality
+- **현재**: `limit == 0` 조건이 두 번 검사된다. 첫 번째는 기본값 할당(`limit = defaultListLimit`)이고, 두 번째(`limit == 0`인 경우 ValidationError 반환)는 첫 번째 블록이 이미 0을 `defaultListLimit`으로 치환했으므로 도달 불가능한 코드다.
+
+  ```go
+  limit := filter.Limit
+  if limit == 0 {
+      limit = defaultListLimit  // 0을 defaultListLimit으로 치환
+  }
+  if limit < 0 {
+      return ..., newValidationError("limit", "0 이상이어야 합니다")
+  }
+  if limit > maxListLimit {
+      return ..., newValidationError("limit", ...)
+  }
+  if limit == 0 {  // 이 분기는 절대 실행되지 않는다
+      return ..., newValidationError("limit", "0보다 커야 합니다")
+  }
+  ```
+- **제안**: 도달 불가능한 마지막 `if limit == 0` 블록을 제거한다. 음수 처리는 `limit < 0`으로 충분하다.
+
+  ```go
+  limit := filter.Limit
+  if limit == 0 {
+      limit = defaultListLimit
+  }
+  if limit < 0 {
+      return repository.ListFilter{}, 0, newValidationError("limit", "0 이상이어야 합니다")
+  }
+  if limit > maxListLimit {
+      return repository.ListFilter{}, 0, newValidationError("limit", fmt.Sprintf("%d 이하여야 합니다", maxListLimit))
+  }
+  ```
+- **근거**: 이 dead code는 기존 PR에서 이미 존재했을 수 있으나, 이번 PR의 `normalizeListFilter` 수정 범위에 포함된다. 불필요한 조건문은 코드 가독성을 해치고 잘못된 이해를 유발할 수 있다.
+
+---
+
+### [Medium] `LogCard.tsx`의 "View log" 문구가 draft 카드에서 혼선 유발
+
+- **파일**: `frontend/src/components/LogCard.tsx:173`
+- **카테고리**: Quality
+- **현재**: 카드 하단 footer에 `<span>View log</span>`이 항상 렌더된다. draft 카드는 클릭 시 상세 페이지가 아닌 수정 폼(`/logs/:id/edit`)으로 이동하는데, "View log"라는 문구는 상세 보기 의도를 암시해 사용자에게 혼선을 준다.
+
+  ```tsx
+  <span className="transition group-hover:translate-x-1">View log</span>
+  ```
+- **제안**: draft 여부에 따라 문구를 분기한다.
+
+  ```tsx
+  <span className="transition group-hover:translate-x-1">
+    {isDraft ? '이어서 작성' : 'View log'}
+  </span>
+  ```
+- **근거**: plan.md "드래프트 카드의 to 분기" 설계에서 클릭 시 수정 폼으로 이동하는 것을 명시했다. 링크 목적지와 문구가 불일치하면 사용자가 드래프트 상태를 오해할 수 있다.
+
+---
+
+### [Low] `buildLogPayload`에서 draft 모드임에도 `normalizeText`로 빈 문자열을 `undefined`로 변환
+
+- **파일**: `frontend/src/pages/logFormState.ts:329-330`
+- **카테고리**: Quality
+- **현재**: `buildLogPayload`에서 cafe draft 모드일 때 `cafe_name`과 `coffee_name`은 `.trim()`으로 빈 문자열 그대로 전달하지만, 이 함수 내 옵셔널 필드(location, beanOrigin 등)는 `normalizeText`를 통해 빈 문자열이 `undefined`로 변환된다. 이 자체는 의도된 동작이나(plan.md 6. 선택 필드 처리 정책과 일치), 함수 내 주석이나 옵션 분기가 없어 "draft이면 빈 문자열 그대로"라는 설명이 cafe_name/coffee_name에만 국한된 것임을 파악하기 어렵다.
+- **제안**: `buildLogPayload` 함수 내 관련 블록에 주석을 추가한다.
+
+  ```ts
+  if (state.logType === 'cafe') {
+    payload.cafe = {
+      // draft/published 모두 trim 후 그대로 전달한다.
+      // draft는 백엔드 draft 검증기에 필수 필드 검증을 위임한다(plan.md 6항 참조).
+      cafe_name: state.cafe.cafeName.trim(),
+      coffee_name: state.cafe.coffeeName.trim(),
+      tasting_tags: state.cafe.tastingTags,
+    }
+    // 옵셔널 필드는 status와 무관하게 빈 값이면 undefined로 정규화한다.
+    const location = normalizeText(state.cafe.location)
+    // ...
+  }
+  ```
+- **근거**: AGENTS.md "주석은 한국어로"(기술 용어는 원문 유지) 정책. 의도를 명시적으로 문서화하면 향후 기여자가 draft/published 분기 누락을 실수로 추가하는 것을 방지할 수 있다.
+
+---
+
+### [Low] `RecipePickerModal`이 published 로그만 표시하지 않음
+
+- **파일**: `frontend/src/pages/LogFormPage.tsx:230`
+- **카테고리**: Quality
+- **현재**: `RecipePickerModal` 내부의 `useLogList({ log_type: 'brew' })` 호출에 `status` 파라미터가 없다. 기본값이 published이므로 현재는 안전하지만, 코드만 보면 draft brew 로그가 레시피 목록에 포함될 가능성을 배제하기 어렵다. plan.md "통계/자동완성 격리" 섹션에서 "기본 목록 호출만으로 published만 집계된다"라고 명시하고 있으나, 의도를 코드에서 명시적으로 표현하지 않는다.
+
+  ```tsx
+  // 현재
+  const { data, ... } = useLogList({ log_type: 'brew' })
+
+  // 제안: 의도를 명시
+  const { data, ... } = useLogList({ log_type: 'brew', status: 'published' })
+  ```
+- **제안**: `status: 'published'`를 명시적으로 전달한다.
+- **근거**: AGENTS.md 코드 컨벤션상 기본값 의존보다 명시적 표현이 선호된다. 레시피 목록에 draft brew 로그(미완성 bean_name)가 표시되면 혼란을 줄 수 있다.
+
+---
+
+## 액션 아이템
+
+1. **[High]** `backend/internal/repository/suggestion_repository_test.go`의 기존 `INSERT INTO coffee_logs` 구문 9개 모두에 `status, 'published'`를 컬럼/값 목록에 추가한다. (37-55, 57-80, 82-105, 107-135, 137-161, 163-187, 193-217, 219-240, 242-263 라인 부근)
+
+2. **[High]** `frontend/src/pages/LogFormPage.test.tsx`에 임시 저장 버튼 테스트를 추가한다: (a) 신규 cafe 폼에서 "임시 저장" 버튼 표시, (b) 빈 폼 → disabled, (c) cafe_name 입력 → enabled, (d) 클릭 → `createLog` mock에 `status: 'draft'` 전달 및 홈으로 navigate, (e) published 수정 모드 → 버튼 미표시, (f) draft 수정 모드 → 버튼 표시 + 클릭 → `updateLog`에 `status: 'draft'` 전달.
+
+3. **[Medium]** `frontend/src/pages/LogDetailPage.tsx`의 상세 컨텐츠 렌더 조건을 `{log && log.status !== 'draft' ? ... : null}`로 변경하여 draft redirect 중 상세 내용이 순간 노출되지 않도록 한다. (159번 라인 부근)
+
+4. **[Medium]** `backend/internal/service/log_service.go`의 `normalizeListFilter`에서 도달 불가능한 `if limit == 0` 블록(411-413 라인)을 제거한다.
+
+5. **[Medium]** `frontend/src/components/LogCard.tsx`의 173번 라인 `<span>View log</span>`을 `<span>{isDraft ? '이어서 작성' : 'View log'}</span>`으로 변경한다.
+
+6. **[Low]** `frontend/src/pages/LogFormPage.tsx`의 `RecipePickerModal` 내 `useLogList({ log_type: 'brew' })` 호출을 `useLogList({ log_type: 'brew', status: 'published' })`로 변경하여 의도를 명시한다. (230번 라인 부근)
+
+7. **[Low]** `frontend/src/pages/logFormState.ts`의 `buildLogPayload` cafe 블록 시작부에 draft 위임 의도를 설명하는 한국어 주석을 추가한다. (328-330번 라인 부근)


### PR DESCRIPTION
## 배경

현재 `actions/checkout@v4`, `actions/setup-node@v4`, `actions/setup-go@v5`가 모두 deprecated된 Node 20 런타임에서 실행된다. GitHub 일정상 **2026-06-02**부터 Node 24로 강제 전환되고 **2026-09-16**에 Node 20이 runner에서 완전 제거된다. 강제 전환 이전에 액션 메이저 버전을 Node 24 지원본으로 올려 deprecation 경고를 해소한다.

Closes #19

## 변경 내용

`.github/workflows/ci.yml`, `.github/workflows/deploy.yml`의 액션 핀 총 7곳을 교체했다.

| 액션 | 변경 | 위치 |
|---|---|---|
| `actions/checkout` | v4 → v5 | ci.yml × 3, deploy.yml × 1 |
| `actions/setup-node` | v4 → v5 | ci.yml × 2 |
| `actions/setup-go` | v5 → v6 | ci.yml × 1 |

`with:` 블록의 모든 입력(`node-version`, `cache`, `cache-dependency-path`, `go-version-file`)은 새 메이저에서도 그대로 호환되어 변경 없음.

## 버전 선택 근거

- **`checkout` v5 채택 (v6 보류)**: v5가 Node 24 도입 최초 메이저. v6는 자격증명 저장 방식 변경으로 runner v2.329.0+ 요구가 추가되며, 본 이슈 목적인 deprecation 해소엔 불필요한 변경 폭이라 보류.
- **`setup-node` v5 채택 (v6 보류)**: v6는 자동 캐싱이 npm 한정으로 좁혀짐. 본 프로젝트는 명시적 `cache: npm`을 쓰지만 변경 폭 최소화를 위해 v5 선택.
- **`setup-go` v6 채택**: 우리가 쓰는 입력은 `go-version-file` 한 가지이며 v6에서도 호환. 회귀 위험이 낮아 최신 메이저로 직진.

## 검증 전략

로컬 재현 없이 PR CI 실행으로 단일 검증.

- `backend-test`, `frontend-unit-test`, `frontend-type-check` 3개 job 모두 success
- 각 job raw 로그에서 `Node.js 20 actions are deprecated` 문자열 0건
- main squash-merge 후 자동 트리거되는 Deploy 워크플로우 통과 + fly.io 정상 응답

## 관련 문서

- 설계 상세: `docs/issues/19-actions-node24-upgrade/plan.md`
- 작업 단계: `docs/issues/19-actions-node24-upgrade/tasks.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)